### PR TITLE
Revert "isisd: When the ISIS types of the routers do not match on a P2P link, the neighbor status remains UP."

### DIFF
--- a/isisd/isis_pdu.c
+++ b/isisd/isis_pdu.c
@@ -231,8 +231,7 @@ static int process_p2p_hello(struct iih_info *iih)
 			return ISIS_OK;
 		}
 	}
-	if (!adj || adj->level != iih->calculated_type ||
-	    !(iih->circuit->is_type & iih->circ_type)) {
+	if (!adj || adj->level != iih->calculated_type) {
 		if (!adj) {
 			adj = isis_new_adj(iih->sys_id, NULL,
 					   iih->calculated_type, iih->circuit);


### PR DESCRIPTION
Reverts zhou-run/frr#2