### PR TITLE
isisd: (test own)The neighbor entry still displays the deleted hostname

### DIFF
--- a/isisd/isis_adjacency.c
+++ b/isisd/isis_adjacency.c
@@ -293,7 +293,7 @@ const char *isis_adj_name(const struct isis_adjacency *adj)
 	struct isis_dynhn *dyn;
 
 	dyn = dynhn_find_by_id(adj->circuit->isis, adj->sysid);
-	if (dyn)
+	if (adj->circuit->area->dynhostname && dyn)
 		return dyn->hostname;
 
 	snprintfrr(buf, sizeof(buf), "%pSY", adj->sysid);

--- a/isisd/isis_lsp.c
+++ b/isisd/isis_lsp.c
@@ -482,13 +482,18 @@ static void lsp_update_data(struct isis_lsp *lsp, struct isis_lsp_hdr *hdr,
 
 	lsp->tlvs = tlvs;
 
-	if (area->dynhostname && lsp->tlvs->hostname
-	    && lsp->hdr.rem_lifetime) {
-		isis_dynhn_insert(
-			area->isis, lsp->hdr.lsp_id, lsp->tlvs->hostname,
-			(lsp->hdr.lsp_bits & LSPBIT_IST) == IS_LEVEL_1_AND_2
-				? IS_LEVEL_2
-				: IS_LEVEL_1);
+	if (area->dynhostname) {
+		if (lsp->tlvs->hostname) {
+			if (lsp->hdr.rem_lifetime) {
+				isis_dynhn_insert(
+					area->isis, lsp->hdr.lsp_id, lsp->tlvs->hostname,
+					(lsp->hdr.lsp_bits & LSPBIT_IST) == IS_LEVEL_1_AND_2
+						? IS_LEVEL_2
+						: IS_LEVEL_1);
+			}
+		} else {
+			isis_dynhn_remove(area->isis, lsp->hdr.lsp_id);
+		}
 	}
 
 	return;


### PR DESCRIPTION
1. The lsp_update_data() function will check for the presence of the ISIS_TLV_DYNAMIC_HOSTNAME in the LSP, and then call isis_dynhn_insert() to add a hostname entry corresponding to the LSP ID. However, when the ISIS_TLV_DYNAMIC_HOSTNAME is not present in the LSP, the hostname entry corresponding to the LSP ID should also be deleted.
2. The command “show isis neighbor” invokes isis_adj_name() to display the System ID or hostname, but it does not check the area->dynhostname flag.